### PR TITLE
fix(encode) fix object property null issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - 'iojs-1'
+  - '0.12'
   - '0.11'
   - '0.10'
 script: "make test-travis"

--- a/lib/v1/encoder.js
+++ b/lib/v1/encoder.js
@@ -299,7 +299,9 @@ proto._writeObject = function (obj) {
  * : {$class: 'java.lang.Map', $: {a: 1}}
  */
 proto.writeObject = function (obj) {
-  if (is.nullOrUndefined(obj)) {
+  if (is.nullOrUndefined(obj) || 
+    // : { a: { '$class': 'xxx', '$': null } }
+    (is.string(obj.$class) && is.nullOrUndefined(obj.$))) {
     debug('writeObject with a null');
     return this.writeNull();
   }

--- a/test/long.test.js
+++ b/test/long.test.js
@@ -23,6 +23,13 @@ var utils = require('./utils');
 describe('long.test.js', function () {
   var longBuffer = new Buffer(['L'.charCodeAt(0), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x2c]);
 
+  it('should write {$class: "java.lang.Long", $: null} => null', function () {
+    var obj = hessian.decode(hessian.encode({
+      $class: "java.lang.Long", $: null
+    }));
+    should.ok(obj === null);
+  });
+
   it('should read long 300', function () {
     hessian.decode(longBuffer).should.equal(300);
   });

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -20,6 +20,26 @@ var utils = require('./utils');
 describe('object.test.js', function () {
   describe('v1.0', function () {
 
+    it('should write null for property like: { a: { "$class": "yyy.yyy", "$": null } }', function () {
+      var o = { '$class': 'xxx.xxx',
+                '$': { a: { '$class': 'yyy.yyy', '$': null } } };
+      var rightBuf = new Buffer('4d7400077878782e787878530001614e7a', 'hex');
+
+      var buf = hessian.encode(o, '1.0');
+      buf.should.length(rightBuf.length);
+      buf.should.eql(rightBuf);
+    });
+
+    it('should write object for property like: { a: { "$class": "yyy.yyy", "$": {} } }', function () {
+      var o = { '$class': 'xxx.xxx',
+                '$': { a: { '$class': 'yyy.yyy', '$': {} } } };
+      var rightBuf = new Buffer('4d7400077878782e787878530001614d7400077979792e7979797a7a', 'hex');
+
+      var buf = hessian.encode(o, '1.0');
+      buf.should.length(rightBuf.length);
+      buf.should.eql(rightBuf);
+    });
+
     it('should _assertType error when encode wrong object', function () {
       var req = {
         $class: 'com.alipay.x.biz.User',

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -51,7 +51,7 @@ describe('object.test.js', function () {
         buf = hessian.encode(req, '1.0');
       } catch (err) {
         rs = err;
-      };
+      }
       should.exist(rs);
       rs.message.should.containEql('com.alipay.x.biz.User');
       should.not.exist(buf);


### PR DESCRIPTION
- should write null for property like: { a: { "$class": "yyy.yyy", "$": null } }

issue #40