### PR TITLE
fix(writeLong) hessian2.0 write long bug

### DIFF
--- a/lib/v2/encoder.js
+++ b/lib/v2/encoder.js
@@ -19,6 +19,7 @@ var is = require('is-type-of');
 var util = require('util');
 var EncoderV1 = require('../v1/encoder');
 var javaObject = require('../object');
+var utility = require('utility');
 
 var SUPPORT_ES6_MAP = typeof Map === 'function' && typeof Map.prototype.forEach === 'function';
 
@@ -74,6 +75,7 @@ var INT_SHORT_ZERO = 0xd4;    // 212
  * ```
  */
 proto.writeInt = function (val) {
+  this._assertType('writeInt', 'int32', val);
   if (INT_DIRECT_MIN <= val && val <= INT_DIRECT_MAX) {
     this.byteBuffer.put(val + INT_ZERO);
   } else if (INT_BYTE_MIN <= val && val <= INT_BYTE_MAX) {
@@ -140,6 +142,10 @@ proto.writeInt = function (val) {
  * ```
  */
 proto.writeLong = function (val) {
+  if (typeof val !== 'number' && utility.isSafeNumberString(val)) {
+    val = Number(val);
+  }
+
   if (val >= -8 && val <= 15) {
     this.byteBuffer.put(val + 0xe0);
   } else if (val >= -2048 && val <= 2047) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "byte": "~1.1.1",
     "debug": "~2.1.3",
-    "is-type-of": "~0.3.1"
+    "is-type-of": "~0.3.1",
+    "utility": "~1.4.0"
   },
   "devDependencies": {
     "autod": "*",

--- a/test/long.test.js
+++ b/test/long.test.js
@@ -233,6 +233,123 @@ describe('long.test.js', function () {
       buf.should.eql(new Buffer([0x4c, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00]));
     });
 
+    it('should write { $class: "long": $: "..." } ok', function () {
+      // -8 ~ 15
+      var buf = hessian.encode(java.long('0'), '2.0');
+      buf.should.length(1);
+      buf[0].should.equal(0xe0);
+      buf.should.eql(new Buffer([0xe0]));
+
+      buf = hessian.encode(java.long('-8'), '2.0');
+      buf.should.length(1);
+      buf[0].should.equal(0xd8);
+      buf.should.eql(new Buffer([0xd8]));
+
+      buf = hessian.encode(java.long('-7'), '2.0');
+      buf.should.length(1);
+      buf[0].should.equal(0xd9);
+      buf.should.eql(new Buffer([0xd9]));
+
+      buf = hessian.encode(java.long('15'), '2.0');
+      buf.should.length(1);
+      buf[0].should.equal(0xef);
+      buf.should.eql(new Buffer([0xef]));
+
+      buf = hessian.encode(java.long('14'), '2.0');
+      buf.should.length(1);
+      buf[0].should.equal(0xee);
+      buf.should.eql(new Buffer([0xee]));
+
+      // -2048 ~ 2047
+      buf = hessian.encode(java.long('-9'), '2.0');
+      buf.should.length(2);
+      buf[0].should.equal(0xf7);
+      buf[1].should.equal(0xf7);
+      buf.should.eql(new Buffer([0xf7, 0xf7]));
+
+      buf = hessian.encode(java.long('16'), '2.0');
+      buf.should.length(2);
+      buf[0].should.equal(0xf8);
+      buf[1].should.equal(0x10);
+      buf.should.eql(new Buffer([0xf8, 0x10]));
+
+      buf = hessian.encode(java.long('255'), '2.0');
+      buf.should.length(2);
+      buf[0].should.equal(0xf8);
+      buf[1].should.equal(0xff);
+      buf.should.eql(new Buffer([0xf8, 0xff]));
+
+      buf = hessian.encode(java.long('-2048'), '2.0');
+      buf.should.length(2);
+      buf[0].should.equal(0xf0);
+      buf[1].should.equal(0);
+      buf.should.eql(new Buffer([0xf0, 0x00]));
+
+      buf = hessian.encode(java.long('2047'), '2.0');
+      buf.should.length(2);
+      buf[0].should.equal(0xff);
+      buf[1].should.equal(0xff);
+      buf.should.eql(new Buffer([0xff, 0xff]));
+
+      // -262144 ~ 262143
+      buf = hessian.encode(java.long('262143'), '2.0');
+      buf.should.length(3);
+      buf[0].should.equal(0x3f);
+      buf[1].should.equal(0xff);
+      buf[2].should.equal(0xff);
+      buf.should.eql(new Buffer([0x3f, 0xff, 0xff]));
+
+      buf = hessian.encode(java.long('-262144'), '2.0');
+      buf.should.length(3);
+      buf[0].should.equal(0x38);
+      buf[1].should.equal(0);
+      buf[2].should.equal(0);
+      buf.should.eql(new Buffer([0x38, 0x00, 0x00]));
+
+      buf = hessian.encode(java.long('2048'), '2.0');
+      buf.should.length(3);
+      buf[0].should.equal(0x3c);
+      buf[1].should.equal(0x08);
+      buf[2].should.equal(0x00);
+      buf.should.eql(new Buffer([0x3c, 0x08, 0x00]));
+
+      buf = hessian.encode(java.long('-2049'), '2.0');
+      buf.should.length(3);
+      buf[0].should.equal(0x3b);
+      buf[1].should.equal(0xf7);
+      buf[2].should.equal(0xff);
+      buf.should.eql(new Buffer([0x3b, 0xf7, 0xff]));
+
+      // -2147483648 ~ 2147483647
+      buf = hessian.encode(java.long('-2147483648'), '2.0');
+      buf.should.length(5);
+      buf[0].should.equal(0x59);
+      buf[1].should.equal(0x80);
+      buf[2].should.equal(0x00);
+      buf[3].should.equal(0x00);
+      buf[4].should.equal(0x00);
+      buf.should.eql(new Buffer([0x59, 0x80, 0x00, 0x00, 0x00]));
+
+      buf = hessian.encode(java.long('2147483647'), '2.0');
+      buf.should.length(5);
+      buf[0].should.equal(0x59);
+      buf[1].should.equal(0x7f);
+      buf[2].should.equal(0xff);
+      buf[3].should.equal(0xff);
+      buf[4].should.equal(0xff);
+      buf.should.eql(new Buffer([0x59, 0x7f, 0xff, 0xff, 0xff]));
+
+      // L
+      buf = hessian.encode(java.long('2147483648'), '2.0');
+      buf.should.length(9);
+      buf.should.eql(new Buffer([0x4c, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00]));
+
+      // unsafe long value
+      buf = hessian.encode(java.long('9007199254740992'), '2.0');
+      buf.should.length(9);
+      buf.should.eql(new Buffer([0x4c, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
+    });
+
     it('should write and read equal java impl', function () {
       hessian.encode(java.long(0), '2.0').should.eql(utils.bytes('v2/long/0'));
       hessian.decode(utils.bytes('v2/long/0'), '2.0').should.equal(0);


### PR DESCRIPTION
- writeLong method to support string val

之前有个bug，没有兼容long类型传string的情况，下面case就报错了

```
hessian.encode({
  $class: 'long',
  $: '2'
}, 2.0);

// HSFEncodeRequestError: src.copy is not a function
```