### PR TITLE
fix: output Number.MAX_SAFE_INTEGER as string rather than number

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -25,7 +25,7 @@
                                 //   "double" : require double quotes
     "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
     "unused"        : false,    // true: Require all defined variables be used
-    "strict"        : true,     // true: Requires all functions run in ES5 Strict Mode
+    "strict"        : "global",     // true: Requires all functions run in ES5 Strict Mode
     "trailing"      : false,    // true: Prohibit trailing whitespaces
     "maxparams"     : false,    // {int} Max number of formal params allowed per function
     "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
@@ -45,7 +45,6 @@
     "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
     "expr"          : true,      // true: Tolerate `ExpressionStatement` as Programs
     "funcscope"     : false,     // true: Tolerate defining variables inside control statements"
-    "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
     "iterator"      : false,     // true: Tolerate using the `__iterator__` property
     "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
     "laxbreak"      : true,      // true: Tolerate possibly unsafe line breakings

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,13 +10,11 @@
 'use strict';
 
 var debug = require('debug')('hessian.js:utils');
+var Long = require('long');
 var object = require('./object');
 
-var MAX_INT_8 = exports.MAX_INT_8 = Math.pow(2, 7);
-var MAX_INT_16 = exports.MAX_INT_16 = Math.pow(2, 15);
-var MAX_INT_32 = exports.MAX_INT_32 = Math.pow(2, 31);
-var MAX_INT = exports.MAX_INT = Math.pow(2, 53);
-var MAX_INT_HIGH = exports.MAX_INT_HIGH = Math.pow(2, 21);
+var MAX_SAFE_INT = Long.fromNumber(Math.pow(2, 53) - 1);
+var MIN_SAFE_INT = Long.fromNumber(1 - Math.pow(2, 53));
 
 var MAX_BYTE_TRUNK_SIZE = exports.MAX_BYTE_TRUNK_SIZE = 0x8000;
 var MAX_CHAR_TRUNK_SIZE = exports.MAX_CHAR_TRUNK_SIZE = 0x8000;
@@ -39,14 +37,10 @@ exports.isJavaObject = function (type) {
 };
 
 exports.handleLong = function (val) {
-  var notSafeInt = val.high > MAX_INT_HIGH ||       // bigger than 2^54
-    (val.high === MAX_INT_HIGH && val.low > 0) ||   // between 2^53 ~ 2^54
-    val.high < -1 * MAX_INT_HIGH ||                 // smaller than -2^54
-    (val.high === -1 * MAX_INT_HIGH && val.low < 0);// between -2^54 ~ -2^53
-
-  if (notSafeInt) {
-    debug('[hessian.js Warning] Read a not safe long, translate it to string');
-    return val.toString();
+  if (val.gt(MAX_SAFE_INT) || val.lt(MIN_SAFE_INT)) {
+    val = val.toString();
+    debug('[hessian.js Warning] Read a not safe long(%s), translate it to string', val);
+    return val;
   }
   return val.toNumber();
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,7 +37,7 @@ exports.isJavaObject = function (type) {
 };
 
 exports.handleLong = function (val) {
-  if (val.gt(MAX_SAFE_INT) || val.lt(MIN_SAFE_INT)) {
+  if (val.greaterThan(MAX_SAFE_INT) || val.lessThan(MIN_SAFE_INT)) {
     val = val.toString();
     debug('[hessian.js Warning] Read a not safe long(%s), translate it to string', val);
     return val;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "byte": "~1.1.1",
     "debug": "~2.2.0",
     "is-type-of": "~0.3.1",
-    "utility": "~1.4.0"
+    "utility": "~1.4.0",
+    "long": "~3.0.1"
   },
   "devDependencies": {
     "autod": "*",
@@ -45,7 +46,6 @@
     "istanbul": "*",
     "js-to-java": "~2.0.6",
     "jshint": "*",
-    "long": "~2.2.3",
     "mocha": "*",
     "should": "~5.2.0"
   },

--- a/test/v1.test.js
+++ b/test/v1.test.js
@@ -110,7 +110,8 @@ describe('hessian v1', function () {
         [-1, '<Buffer 4c ff ff ff ff ff ff ff ff>'],
         [0, '<Buffer 4c 00 00 00 00 00 00 00 00>'],
         [10000, '<Buffer 4c 00 00 00 00 00 00 27 10>'],
-        [9007199254740992, '<Buffer 4c 00 20 00 00 00 00 00 00>'],
+        [9007199254740991, '<Buffer 4c 00 1f ff ff ff ff ff ff>'],
+        ['9007199254740992', '<Buffer 4c 00 20 00 00 00 00 00 00>'],
         ['9007199254740993', '<Buffer 4c 00 20 00 00 00 00 00 01>'],
         ['9223372036854775807', '<Buffer 4c 7f ff ff ff ff ff ff ff>'],
       ];


### PR DESCRIPTION
如题，关联 issue #56 