### PR TITLE
fix: fix encode/decode date bug

### DIFF
--- a/lib/v2/decoder.js
+++ b/lib/v2/decoder.js
@@ -301,7 +301,7 @@ proto.readDate = function () {
     return new Date(utils.handleLong(this.byteBuffer.getLong()));
   }
   if (code === 0x4b) {
-    return new Date(this.byteBuffer.getUInt32() * 60000);
+    return new Date(this.byteBuffer.getInt32() * 60000);
   }
 
   this.throwError('readDate', code);

--- a/lib/v2/encoder.js
+++ b/lib/v2/encoder.js
@@ -259,7 +259,7 @@ proto.writeDate = function (milliEpoch) {
     if ((minutes >> 31) === 0 || (minutes >> 31)  === -1) {
       this.byteBuffer
         .put(0x4b)
-        .putUInt32(minutes);
+        .putInt32(minutes);
       return this;
     }
   }

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -89,6 +89,13 @@ describe('date.test.js', function () {
       hessian.decode(utils.bytes('v2/date/now'), '2.0').should.eql(now);
     });
 
+    it('should write and read Wed Jan 04 1950 00:00:00 GMT+0800 (CST)', function () {
+      var date = new Date('Wed Jan 04 1950 00:00:00 GMT+0800 (CST)');
+      var bin = new Buffer('4bff5f8c60', 'hex');
+      hessian.encode(date, '2.0').should.eql(bin);
+      hessian.decode(bin, '2.0').should.eql(date);
+    });
+
     // it('should read 1.0 format', function () {
     //   hessian.decode(utils.bytes('v1/date/894621091000'), '2.0').getTime()
     //     .should.equal(894621091000);


### PR DESCRIPTION
当日期小于1970年，时间是负数

putUInt32 => putInt32  
getUInt32 => getInt32

```js
encode({ stationId: 31353,
  source: 'partner_signle_add',
  customerType: 'personal',
  name: 'aaa',
  mobile: '11111111111',
  sex: 'M',
  birthday: new Date('Wed Jan 04 1950 00:00:00 GMT+0800 (CST)'),
  peopleStyle: 'normal_population',
  formerName: '',
  address: 
   { provinceId: '330000',
     cityId: '330100',
     countyId: '330110',
     townId: '330110003',
     addressDetail: 'fefef' } }, '2.0');

buffer.js:829
    throw new TypeError('value is out of bounds');
    ^

TypeError: value is out of bounds
    at checkInt (buffer.js:829:11)
    at Buffer.writeUInt32BE (buffer.js:922:5)
    at ByteBuffer.(anonymous function) [as putUInt32]
```