### PR TITLE
fix: modify Map detect logic to support vm.runInNewContext

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,7 @@
 var debug = require('debug')('hessian.js:utils');
 var Long = require('long');
 var object = require('./object');
+var toString = Object.prototype.toString;
 
 var MAX_SAFE_INT = Long.fromNumber(Math.pow(2, 53) - 1);
 var MIN_SAFE_INT = Long.fromNumber(1 - Math.pow(2, 53));
@@ -81,4 +82,8 @@ exports.addByteCodes = function addByteCodes(map, codes, method) {
       map[code] = method;
     }
   }
+};
+
+exports.isMap = function isMap(val) {
+  return toString.call(val) === '[object Map]';
 };

--- a/lib/v1/encoder.js
+++ b/lib/v1/encoder.js
@@ -264,7 +264,7 @@ proto._writeHashMap = function (obj) {
   // hashmap's type is null
   this.writeType('');
 
-  if (supportES6Map && obj instanceof Map) {
+  if (supportES6Map && utils.isMap(obj)) {
     obj.forEach(function (value, key) {
       this.write(key);
       this.write(value);

--- a/lib/v2/encoder.js
+++ b/lib/v2/encoder.js
@@ -20,6 +20,7 @@ var util = require('util');
 var EncoderV1 = require('../v1/encoder');
 var javaObject = require('../object');
 var utility = require('utility');
+var isMap = require('../utils').isMap;
 var supportES6Map = require('../utils').supportES6Map;
 
 function Encoder(options) {
@@ -583,7 +584,7 @@ proto._writeHashMap = function (obj) {
 
   this.byteBuffer.put(0x48); // H
 
-  if (supportES6Map && obj instanceof Map) {
+  if (supportES6Map && isMap(obj)) {
     obj.forEach(function (value, key) {
       this.write(key);
       this.write(value);


### PR DESCRIPTION
支持 vm.runInNewContext 里产生的 Map

```js
var map = vm.runInNewContext('(function() { return new Map() })()', {});
map.set({ '$class': 'java.lang.Long', '$': 123 }, 123456);
map.set({ '$class': 'java.lang.Long', '$': 123456 }, 123);
var buf = hessian.encode(map);
```