### PR TITLE
feat: upgrade is-type-of to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   },
   "homepage": "https://github.com/node-modules/hessian.js",
   "dependencies": {
-    "byte": "~1.1.5",
-    "debug": "~2.6.7",
-    "is-type-of": "~1.0.0",
-    "utility": "~1.6.0",
-    "long": "~3.1.0"
+    "byte": "^1.1.6",
+    "debug": "^2.6.8",
+    "is-type-of": "^1.1.0",
+    "long": "^3.2.0",
+    "utility": "^1.12.0"
   },
   "devDependencies": {
     "autod": "*",


### PR DESCRIPTION
avoid using toString() to type check

- https://github.com/node-modules/hessian.js/pull/76/files#r117784718
- https://github.com/node-modules/is-type-of/pull/4
- https://github.com/node-modules/is-type-of/pull/5

pick from https://github.com/node-modules/hessian.js/pull/80