### PR TITLE
fix: change the way to check whether is exception or not

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
   - '4'

--- a/lib/object.js
+++ b/lib/object.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var util = require('util');
+var has = require('utility').has;
 
 exports.DEFAULT_CLASSNAME = {
   boolean: 'boolean',
@@ -160,5 +161,12 @@ function JavaExceptionError(obj, withType) {
 }
 
 util.inherits(JavaExceptionError, Error);
+
+exports.isJavaException = function (obj) {
+  if (has(obj, 'detailMessage') && has(obj, 'cause') && has(obj, 'stackTrace')) {
+    return true;
+  }
+  return false;
+};
 
 exports.JavaExceptionError = JavaExceptionError;

--- a/lib/v1/decoder.js
+++ b/lib/v1/decoder.js
@@ -15,6 +15,7 @@ var ByteBuffer = require('byte');
 var is = require('is-type-of');
 var utils = require('../utils');
 var object = require('../object');
+var isJavaException = object.isJavaException;
 var JavaExceptionError = object.JavaExceptionError;
 
 var BYTE_CODES = {};
@@ -410,7 +411,7 @@ proto.readObject = function (withType) {
   debug('read object finish');
 
   // java.lang.NoClassDefFoundError
-  if (/Exception$/.test(type) || /^java\.lang\.\w+Error$/.test(type)) {
+  if (isJavaException(result.$)) {
     result.$ = new JavaExceptionError(result, withType);
   }
 

--- a/lib/v2/decoder.js
+++ b/lib/v2/decoder.js
@@ -19,11 +19,17 @@ var is = require('is-type-of');
 var debug = require('debug')('hessian:v2:decoder');
 var DecoderV1 = require('../v1/decoder');
 var utils = require('../utils');
+var isJavaException = require('../object').isJavaException;
 var JavaExceptionError = require('../object').JavaExceptionError;
 var decodeFnCtx = { JavaExceptionError: JavaExceptionError };
 var codegen = require('@protobufjs/codegen');
 
 var BYTE_CODES = {};
+var errorProps = {
+  detailMessage: true,
+  stackTrace: true,
+  cause: true,
+};
 
 function Decoder(buf, classCache) {
   DecoderV1.call(this, buf);
@@ -474,12 +480,16 @@ proto._readObjectDefinition = function () {
   // set class definition into cache
   if (this.classCache) {
     if (this.classCache.enableCompile) {
+      var errorPropCount = 0;
       var gen = codegen(['decoder', 'withType'], 'decode');
       gen('// %s', cachekey);
       gen('var result = {');
       gen('  $class: \'%s\',', classname);
       gen('  $: {');
       for (var field of fields) {
+        if (errorProps[field]) {
+          errorPropCount++;
+        }
         if (INNER_CLASS_LABEL === field) {
           continue;
         }
@@ -495,7 +505,7 @@ proto._readObjectDefinition = function () {
           gen('result.$.%s = decoder.read(withType);', field);
         }
       }
-      if (/Exception$/.test(classname)) {
+      if (errorPropCount === 3) {
         gen('result.$ = new JavaExceptionError(result, withType);');
       }
       gen('return withType ? result : result.$');
@@ -579,7 +589,7 @@ proto.readObject = function (withType) {
     result.$[name] = value;
   }
 
-  if (/Exception$/.test(cls.name)) {
+  if (isJavaException(result.$)) {
     result.$ = new JavaExceptionError(result, withType);
   }
 
@@ -836,7 +846,7 @@ proto.readMap = function (withType) {
   this._addRef(result);
   this._readMap(result.$, withType);
 
-  if (/Exception$/.test(type)) {
+  if (isJavaException(result.$)) {
     result.$ = new JavaExceptionError(result);
   }
 

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   "homepage": "https://github.com/node-modules/hessian.js",
   "dependencies": {
     "@protobufjs/codegen": "^2.0.4",
-    "byte": "^1.2.0",
+    "byte": "^2.0.0",
     "debug": "^3.1.0",
     "is-type-of": "^1.2.0",
-    "long": "^3.2.0",
+    "long": "^4.0.0",
     "utility": "^1.13.1"
   },
   "devDependencies": {
@@ -42,11 +42,11 @@
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.4",
     "istanbul": "^0.4.5",
-    "js-to-java": "^2.4.0",
+    "js-to-java": "^2.5.0",
     "jshint": "^2.9.5",
     "mm": "^2.2.0",
     "mocha": "^3.5.3",
-    "should": "^13.1.3"
+    "should": "^13.2.1"
   },
   "engines": {
     "node": ">= 0.12.0"

--- a/test/v1.test.js
+++ b/test/v1.test.js
@@ -76,7 +76,7 @@ describe('hessian v1', function () {
       tests.forEach(function (t, idx) {
         assert.throws(function () {
           var buf = encoder.writeInt(t);
-        }, 'hessian writeInt expect input type is `int32`, but got `number` : ' + tests[idx] + ' ');
+        }, null, 'hessian writeInt expect input type is `int32`, but got `number` : ' + tests[idx] + ' ');
       });
     });
 
@@ -87,7 +87,7 @@ describe('hessian v1', function () {
       tests.forEach(function (t) {
         assert.throws(function () {
           decoder.init(t[0]).readInt();
-        }, t[1]);
+        }, null, t[1]);
       });
     });
   });
@@ -134,7 +134,7 @@ describe('hessian v1', function () {
       tests.forEach(function (t) {
         assert.throws(function () {
           decoder.init(t[0]).readLong();
-        }, t[1]);
+        }, null, t[1]);
       });
     });
   });
@@ -169,7 +169,7 @@ describe('hessian v1', function () {
       tests.forEach(function (t) {
         assert.throws(function () {
           decoder.init(t[0]).readDouble();
-        }, t[1]);
+        }, null, t[1]);
       });
     });
   });
@@ -198,7 +198,7 @@ describe('hessian v1', function () {
       tests.forEach(function (t) {
         assert.throws(function () {
           decoder.init(t[0]).readDate();
-        }, t[1]);
+        }, null, t[1]);
       });
     });
   });
@@ -229,7 +229,7 @@ describe('hessian v1', function () {
       tests.forEach(function (t) {
         assert.throws(function () {
           var buf = decoder.init(t[0]).readBytes();
-        }, t[1]);
+        }, null, t[1]);
       });
     });
 
@@ -247,16 +247,16 @@ describe('hessian v1', function () {
     it('should write type error', function () {
       assert.throws(function () {
         encoder.writeBytes();
-      }, 'hessian writeBytes expect input type is `buffer`, but got `undefined` : undefined ');
+      }, null, 'hessian writeBytes expect input type is `buffer`, but got `undefined` : undefined ');
       assert.throws(function () {
         encoder.writeBytes('');
-      }, 'hessian writeBytes expect input type is `buffer`, but got `string` : "" ');
+      }, null, 'hessian writeBytes expect input type is `buffer`, but got `string` : "" ');
       assert.throws(function () {
         encoder.writeBytes(null);
-      }, 'hessian writeBytes expect input type is `buffer`, but got `object` : null ');
+      }, null, 'hessian writeBytes expect input type is `buffer`, but got `object` : null ');
       assert.throws(function () {
         encoder.writeBytes(100);
-      }, 'hessian writeBytes expect input type is `buffer`, but got `number` : 100 ');
+      }, null, 'hessian writeBytes expect input type is `buffer`, but got `number` : 100 ');
     });
 
     it('should write and read empty bytes', function () {
@@ -294,24 +294,24 @@ describe('hessian v1', function () {
       tests.forEach(function (t) {
         assert.throws(function () {
           var buf = decoder.init(t[0]).readString();
-        }, t[1]);
+        }, null, t[1]);
       });
     });
 
     it('should write type error', function () {
       assert.throws(function () {
         encoder.writeString();
-      }, 'hessian writeString expect input type is `string`, but got `undefined` : undefined ');
+      }, null, 'hessian writeString expect input type is `string`, but got `undefined` : undefined ');
       // v0.10.28 return [1,2,3,4,5]
       // (function () {
       //   encoder.writeString(new Buffer([1,2,3,4,5]));
       // }).should.throw('hessian writeString expect input type is `string`, but got `object` : {"type":"Buffer","data":[1,2,3,4,5]} ');
       assert.throws(function () {
         encoder.writeString(null);
-      }, 'hessian writeString expect input type is `string`, but got `object` : null ');
+      }, null, 'hessian writeString expect input type is `string`, but got `object` : null ');
       assert.throws(function () {
         encoder.writeString(100);
-      }, 'hessian writeString expect input type is `string`, but got `number` : 100 ');
+      }, null, 'hessian writeString expect input type is `string`, but got `number` : 100 ');
     });
 
     it('should string length equal MAX_CHAR_TRUNK_SIZE work', function () {
@@ -457,13 +457,13 @@ describe('hessian v1', function () {
     it('should write type error', function () {
       assert.throws(function () {
         encoder.writeObject('123');
-      }, 'hessian writeObject / writeMap expect input type is `object`, but got `string` : "123" ');
+      }, null, 'hessian writeObject / writeMap expect input type is `object`, but got `string` : "123" ');
       assert.throws(function () {
         encoder.writeObject(1.111);
-      }, 'hessian writeObject / writeMap expect input type is `object`, but got `number` : 1.111 ');
+      }, null, 'hessian writeObject / writeMap expect input type is `object`, but got `number` : 1.111 ');
       assert.throws(function () {
         encoder.writeObject(100);
-      }, 'hessian writeObject / writeMap expect input type is `object`, but got `number` : 100 ');
+      }, null, 'hessian writeObject / writeMap expect input type is `object`, but got `number` : 100 ');
     });
   });
 
@@ -539,16 +539,16 @@ describe('hessian v1', function () {
     it('should write type error', function () {
       assert.throws(function () {
         encoder.writeArray();
-      }, 'hessian writeArray input type invalid');
+      }, null, 'hessian writeArray input type invalid');
       assert.throws(function () {
         encoder.writeArray('123');
-      }, 'hessian writeArray input type invalid');
+      }, null, 'hessian writeArray input type invalid');
       assert.throws(function () {
         encoder.writeArray(1.111);
-      }, 'hessian writeArray input type invalid');
+      }, null, 'hessian writeArray input type invalid');
       assert.throws(function () {
         encoder.writeArray(100);
-      }, 'hessian writeArray input type invalid');
+      }, null, 'hessian writeArray input type invalid');
     });
   });
 
@@ -615,7 +615,7 @@ describe('hessian v1', function () {
       var buf = new Buffer([0x50, 0x11]);
       assert.throws(function() {
         hessian.decode(buf);
-      }, 'hessian read got an unexpect code: 0x50');
+      }, null, 'hessian read got an unexpect code: 0x50');
     });
   });
 });


### PR DESCRIPTION
以前根据正则来判断不太严谨，上周大佬们开发时候，服务端一个异常对象叫 ErrorContext 不是 Exception 结尾的，没有识别出来，导致错误栈打出来比较奇怪