### PR TITLE
fix decoder 反序列化遇到java类属性重写时，会有bug

### DIFF
--- a/lib/v1/decoder.js
+++ b/lib/v1/decoder.js
@@ -403,7 +403,7 @@ proto.readObject = function (withType) {
   // get
   var label = this.byteBuffer.getChar();
   var key;
-
+  var walkedKeys = {};
   while (label !== 'z') {
     this.byteBuffer.position(this.byteBuffer.position() - 1);
     key = this.read();
@@ -414,6 +414,10 @@ proto.readObject = function (withType) {
     debug('read object prop: %j with type: %s', key, withType);
     if (!/^this\$\d+$/.test(key)) {
       var k = is.object(key) && key.name ? key.name : key;
+      if (walkedKeys['__my_' + k]) {
+        continue;
+      }
+      walkedKeys['__my_' + k] = true;
       result.$[k] = value;
     }
     if (isMap) {

--- a/lib/v2/decoder.js
+++ b/lib/v2/decoder.js
@@ -614,10 +614,15 @@ proto.readObject = function (withType) {
   this._addRef(result);
 
   var fields = cls.fields;
+  var walkedFields = {};
   for (var i = 0; i < fields.length; i++) {
     var name = fields[i];
     var value = this.read(withType);
     if (name !== INNER_CLASS_LABEL) {
+      if (walkedFields['__my_' + name]) {
+        continue;
+      }
+      walkedFields['__my_' + name] = true;
       result.$[name] = value;
     }
   }


### PR DESCRIPTION
例如下面定义的类型B，重新定义了A已经定义的name。java端hessian序列化时会有两个name属性，并且父类的name在后面，但是值为空。原来的hessian.js反序列化会把前面的值覆盖。这个PR可以检测之前是否已经有值，避免被后面的覆盖掉。
```
class A{
    private String name;

    public String getName(){
        return name;
    }
    public String setName(String name){
        return this.name = name;
    }
}

class B extends A {
    private String name;

    public String getName(){
        return name;
    }
    public String setName(String name){
        return this.name = name;
    }
}
```